### PR TITLE
preserve animations

### DIFF
--- a/Mentat/modules/pytaVSL.py
+++ b/Mentat/modules/pytaVSL.py
@@ -434,10 +434,7 @@ class PytaVSL(Module):
 
                     slide.add_parameter(property_name, '/pyta/slide/%s/set' % slide_name, types=types, static_args=[property_name], default=values[0] if len(values) == 1 else values)
                     if property_name == 'scale':
-                        slide.add_meta_parameter('zoom', ['scale'],
-                            getter = lambda scale: scale[0],
-                            setter = lambda zoom: slide.set('scale', zoom)
-                        )
+                        slide.add_alias_parameter('zoom', 'scale')
 
                     if property_name in ['position', 'rotate']:
                         axis = {0: '_x', 1: '_y', 2: '_z'}

--- a/Mentat/modules/pytaVSL.py
+++ b/Mentat/modules/pytaVSL.py
@@ -444,7 +444,7 @@ class PytaVSL(Module):
                                 def setter(val):
                                     value = slide.get(property_name)
                                     value[index] = val
-                                    slide.set(property_name, *value)
+                                    slide.set(property_name, *value, preserve_animation=True)
 
                                 slide.add_meta_parameter(property_name + ax, [property_name],
                                     getter = lambda prop: prop[index],


### PR DESCRIPTION
J'ai ajouté la possibilité de préserver l'animation d'un paramètre dans mentat quand "set()" est appelé (https://github.com/jean-emmanuel/mentat/commit/f967e2fc42e39d92d81f99edea181d59dcfcf3c5) et cette PR l'utilise (en plus de add_alias_parameter que j'avais complètement oublié hier...). Je ne préfère pas le faire par défaut, ça me semble encore pertinent dans la plupart des cas de stopper les animations.